### PR TITLE
Add daily schedule trigger to bronze Lambdas

### DIFF
--- a/bronze/lambda-hackernews/serverless.yaml
+++ b/bronze/lambda-hackernews/serverless.yaml
@@ -46,3 +46,9 @@ functions:
   bronzeHackerNews:
     name: bronze-hackernews-ingestion
     handler: src.handler.lambda_handler
+    events:
+      - schedule:
+          name: daily-hackernews-ingestion-trigger
+          description: "Automatically triggers Hacker News data ingestion every day at 01:00 UTC"
+          rate: cron(0 1 * * ? *) # Runs at 01:00 AM UTC every day
+          enabled: true

--- a/bronze/lambda-x/serverless.yaml
+++ b/bronze/lambda-x/serverless.yaml
@@ -45,3 +45,9 @@ functions:
   bronzeX:
     name: bronze-x-ingestion
     handler: src.handler.lambda_handler
+    events:
+      - schedule:
+          name: daily-hackernews-ingestion-trigger
+          description: "Automatically triggers Hacker News data ingestion every day at 01:00 UTC"
+          rate: cron(0 1 * * ? *) # Runs at 01:00 AM UTC every day
+          enabled: true


### PR DESCRIPTION
Add a scheduled event to bronze/lambda-hackernews and bronze/lambda-x. Each function now includes an events.schedule (name: daily-hackernews-ingestion-trigger) with a description and cron(0 1 * * ? *) to automatically trigger the ingestion Lambdas daily at 01:00 UTC (enabled: true).